### PR TITLE
Remove the lombok dependency from "scim2-sdk-common"

### DIFF
--- a/scim2-sdk-common/build.gradle
+++ b/scim2-sdk-common/build.gradle
@@ -8,6 +8,5 @@ dependencies {
     implementation group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "$jackson_version"
     implementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "$jackson_databind_version"
     implementation group: "com.google.guava", name: "guava", version: "$guava_version"
-    implementation group: "org.projectlombok", name: "lombok"
     testImplementation group: "org.testng", name: "testng", version: "$testng_version"
 }


### PR DESCRIPTION
Lombok should never be a "implementation" dependency which is populated to the users of this library. Also lombok is already properly defined as a compileOnly and annotationProcessor dependency in the parent project so it is not needed in the module at all.