### PR TITLE
Remove unnecessary check for selection filter in AddOperation

### DIFF
--- a/scim2-sdk-common/src/main/java/com/bettercloud/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/bettercloud/scim2/common/messages/PatchOperation.java
@@ -92,18 +92,6 @@ public abstract class PatchOperation
             "value field must be a JSON object containing the attributes to " +
                 "add");
       }
-      if(path != null)
-      {
-        for (Path.Element element : path)
-        {
-          if(element.getValueFilter() != null)
-          {
-            throw BadRequestException.invalidPath(
-                "path field for add operations must not include any value " +
-                    "selection filters");
-          }
-        }
-      }
       this.value = value;
     }
 


### PR DESCRIPTION
The AddOperation does a check for selection filters and throws an Exception if one exists. However, some SCIM providers, like the Azure AD Scim Integration, does in fact use exactly this,for example for adding the work address, which looks like this:

```

(...)
    {
      "op": "Add",
      "path": "addresses[type eq \"work\"].locality",
      "value": "Buxtehude"
    },
(...)
```

We noticed that with just removing the check it works, so I don't think its necessary on this point to forbid this kind of filters in a Add Operation.