### PR TITLE
fixing return url path

### DIFF
--- a/spring-boot-starter-scim2/src/main/java/com/bettercloud/scim2/server/converter/GenericScimResourceConverter.java
+++ b/spring-boot-starter-scim2/src/main/java/com/bettercloud/scim2/server/converter/GenericScimResourceConverter.java
@@ -154,12 +154,12 @@ public class GenericScimResourceConverter<RESOURCE extends ScimResource> {
     }
 
     private URI getBaseUri() {
-        return UriComponentsBuilder.fromHttpUrl(baseUrl).pathSegment(getCurrentRequest().getContextPath()).build().toUri();
+        return UriComponentsBuilder.fromHttpUrl(baseUrl).path(getCurrentRequest().getContextPath()).build().toUri();
     }
 
     private URI getLocationUri() {
         final HttpServletRequest request = getCurrentRequest();
-        return UriComponentsBuilder.fromHttpUrl(baseUrl).pathSegment(request.getContextPath()).pathSegment(request.getServletPath()).build().toUri();
+        return UriComponentsBuilder.fromHttpUrl(baseUrl).path(request.getContextPath()).path(request.getServletPath()).build().toUri();
     }
 
     private HttpServletRequest getCurrentRequest() {


### PR DESCRIPTION
There is an issue with pathSegment() function as it appends path segments to the existing path, and it should not contain any slashes (not this case). It's resulting in a broken URL http://localhost:8080//ServiceProviderConfig

{
  "schemas": [
    "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
  ],
  ...
  "meta": {
    "resourceType": "ServiceProviderConfig",
    "location": "http://localhost:8080//ServiceProviderConfig"
  }
}

I am changing to path() to fix the issue.